### PR TITLE
Change git to http protocol to prevent failure

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "ffmpeg"]
 	path = ffmpeg
-	url = git://git.videolan.org/ffmpeg.git
+	url = http://git.videolan.org/git/ffmpeg.git
 [submodule "x264"]
 	path = x264
-	url = git://git.videolan.org/x264.git
+	url = http://git.videolan.org/git/x264.git
 [submodule "freetype2"]
 	path = freetype2
-	url = git://git.sv.gnu.org/freetype/freetype2.git
+	url = http://git.savannah.gnu.org/r/freetype/freetype2.git
 [submodule "sox"]
 	path = sox
-	url = git://sox.git.sourceforge.net/gitroot/sox/sox
+	url = http://git.code.sf.net/p/sox/code


### PR DESCRIPTION
Some networks don't allow git:// so http:// would be more reliable.

For in depth look at pros and cons: [4.1 Git on the Server - The Protocols](http://git-scm.com/book/en/Git-on-the-Server-The-Protocols)
