### PR TITLE
Fixed Missing newline in Readme.txt

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -22,7 +22,8 @@ building
 cd android-ffmpeg
 git submodule init
 git submodule update
-NDK_BASE=/path/to/android-ndk ./configure_make_everything.sh
+NDK_BASE=/path/to/android-ndk 
+./configure_make_everything.sh
 
 That should give you command line binary ffmpeg/ffmpeg, which is the only file
 you should need.


### PR DESCRIPTION
There should be a line break between
NDK_BASE=/path/to/android-ndk 
and
./configure_make_everything.sh